### PR TITLE
Add missing ETF Type

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const BERT_START = String.fromCharCode(131)
 const SMALL_ATOM = String.fromCharCode(115)
+const SMALL_ATOM_UTF8 = String.fromCharCode(119)
 const ATOM = String.fromCharCode(100)
+const ATOM_UTF8 = String.fromCharCode(118)
 const SMALL_INTEGER = String.fromCharCode(97)
 const MAP = String.fromCharCode(116)
 const INTEGER = String.fromCharCode(98)
@@ -152,7 +154,9 @@ const decodeInner = s => {
 
   switch(type) {
     case SMALL_ATOM: return decodeAtom(s, 1)
+    case SMALL_ATOM_UTF8: return decodeAtom(s, 1)
     case ATOM: return decodeAtom(s, 2)
+    case ATOM_UTF8: return decodeAtom(s, 1)
     case SMALL_INTEGER: return decodeSmallInteger(s)
     case INTEGER: return decodeInteger(s, 4)
     case SMALL_BIG: return decodeBig(s, 1)
@@ -165,7 +169,7 @@ const decodeInner = s => {
     case SMALL_TUPLE: return decodeTuple(s, 1)
     case LARGE_TUPLE: return decodeLargeTuple(s, 4)
     case NIL: return decodeNil(s)
-    default: throw(`Unexpected BERT type: ${s.charCodeAt(0)}`)
+    default: throw(`Unexpected BERT type: ${type.charCodeAt(0)}`)
   }
 }
 


### PR DESCRIPTION
## Description of the change

Source: [External Term Format](https://www.erlang.org/doc/apps/erts/erl_ext_dist.html)

This adds two missing types for decoding: 119 -SMALL_ATOM_UTF8 and 118 - ATOM_UTF8.
I also fixed `decodeInner` to give the correct missing BERT type.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/76670/update-bert-elixer-package

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
